### PR TITLE
feat: add template for java

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -38,6 +38,11 @@
             "description": "A python template supporting ObjectLink support and http client/server"
         },
         {
+            "name": "apigear-io/template-java",
+            "git": "https://github.com/apigear-io/template-java.git",
+            "description": "A Java based template with Android service/client and JNI bridge support"
+        },
+        {
             "name": "apigear-io/template-simulation",
             "git": "https://github.com/apigear-io/template-simulation.git",
             "description": "Generates simulation js code from API definitions, for use in the apigear simulator"


### PR DESCRIPTION
Adds the [template-java](https://github.com/apigear-io/template-java) repository to the registry.

The Java template generates Java interfaces and Android service/client SDKs (Messenger-based IPC, Parcelable serialization, async RPC) plus a JNI bridge for native C++ integration. First versioned release tagged as [v0.1.0](https://github.com/apigear-io/template-java/releases/tag/v0.1.0).